### PR TITLE
Use dns::hoststring and FQDN for in-addr-arpa. RR

### DIFF
--- a/model/_init.cf
+++ b/model/_init.cf
@@ -18,7 +18,7 @@
 import ip
 import ip::services
 
-typedef hoststring as string matching /^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.?$/
+typedef hoststring as string matching /^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.$/
 
 entity Zone:
     """ A dns zone.
@@ -71,7 +71,7 @@ entity Record:
     """
         A generic dns resource record
     """
-    string resource=""
+    string resource
     string value
     string record_type
 end
@@ -80,7 +80,7 @@ Record records [0:] -- [1] Zone zone
 
 entity A extends Record:
     """ An A record
-        
+
         :param ipaddress: The address to point this record to
     """
     ip::ip ipaddress
@@ -99,6 +99,7 @@ implement NS using nsImpl
 
 implementation nsImpl for NS:
     self.value = self.server
+    self.resource = ""
     self.record_type = "ns"
 end
 
@@ -156,4 +157,3 @@ implementation txtImpl for TXT:
 end
 
 implement TXT using txtImpl
-

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -19,7 +19,7 @@ from inmanta.plugins import plugin
 from operator import attrgetter
 
 @plugin
-def ip_to_arpa(ip_addr : "ip::ip") -> "std::hoststring":
+def ip_to_arpa(ip_addr : "ip::ip") -> "dns::hoststring":
     """
         Convert an ip to the addr.arpa notation
     """
@@ -27,7 +27,7 @@ def ip_to_arpa(ip_addr : "ip::ip") -> "std::hoststring":
     parts.reverse()
     addr = ".".join(parts)
 
-    return addr + ".in-addr.arpa"
+    return addr + ".in-addr.arpa."
 
 @plugin
 def filter_record(record : "std::hoststring", zone : "dns::Zone") -> "std::hoststring":


### PR DESCRIPTION
- dns::hoststring is defined with an optional dot at the end, I believe the trailing dot is not optional but should always be there (at least for ip_to_arpa).

- I added a dot to "in-addr.arpa" in ip_to_arpa to assure fqdn for reverse lookup

- I removed the default value from resource in the Zone entity otherwise I couldn't use PTR records,
I got this exception when a default value was set for resource: 
DoubleSetException: Value set twice: old value:   ...new value 102.33.168.192.in-addr.arpa"
(not sure if this is a good solution, just to work around this issue with PTR records)

In my tests, I just tried to set a PTR RR with following command in main.cf:
dns::PTR(zone=zn_33_168_192, name="vm1.example.com.", ipaddress="192.168.33.101")

- as a consequence I had to set an empty string to resource when using NS records